### PR TITLE
Close MySQL Connection After Use

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>edu.whimc</groupId>
 	<artifactId>WHIMC-PositionTracker</artifactId>
-	<version>2.0.2.2</version>
+	<version>2.0.3</version>
 	<name>WHIMC Position Tracker</name>
 	<description>Track player positions to a database</description>
 

--- a/src/main/java/edu/whimc/positiontracker/sql/Queryer.java
+++ b/src/main/java/edu/whimc/positiontracker/sql/Queryer.java
@@ -16,79 +16,78 @@ import org.bukkit.entity.Player;
 import edu.whimc.positiontracker.Tracker;
 
 public class Queryer {
-	
-	public class PositionEntry {
-		
-		private final int x, y, z;
-		private final String world, biome, username;
-		private final UUID uuid;
-		private final Timestamp time;
-		
-		public PositionEntry(Player player) {
-			Location loc = player.getLocation();
-			this.x = loc.getBlockX();
-			this.y = loc.getBlockY();
-			this.z = loc.getBlockZ();
-			this.world = loc.getWorld().getName();
-			this.biome = loc.getBlock().getBiome().name();
-			this.username = player.getName();
-			this.uuid = player.getUniqueId();
-			this.time = new Timestamp(System.currentTimeMillis());
-		}
-		
-		public void addInsertionToBatch(PreparedStatement statement) throws SQLException {
-			statement.setInt(1, x);
-			statement.setInt(2, y);
-			statement.setInt(3, z);
-			statement.setString(4, world);
-			statement.setString(5, biome);
-			statement.setString(6, username);
-			statement.setString(7, uuid.toString());
-			statement.setLong(8, time.getTime() / 1000);
-			statement.addBatch();
-		}
-		
-	}
-	
-	private static final String INSERT_FORMAT =
-			"INSERT INTO `whimc_player_positions` " +
-					"(x, y, z, world, biome, username, uuid, time) " +
-					"VALUES(?, ?, ?, ?, ?, ?, ?, ?)";
-	
-	private Tracker plugin;
-	private MySQLConnection sqlConnection;
-	
-	public Queryer(Tracker plugin, Consumer<Boolean> callback) {
-		this.plugin = plugin;
-		this.sqlConnection = new MySQLConnection(plugin);
-		
-		Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-			final boolean success = sqlConnection.initialize();
-			Bukkit.getScheduler().runTask(plugin, () -> {
-				callback.accept(success);
-			});
-		});
-	}
-	
-	public void storePositionData() {
-		final List<PositionEntry> entries = Bukkit.getOnlinePlayers().stream()
-				.map(v -> new PositionEntry(v))
-				.collect(Collectors.toList());
-		
-		Bukkit.getScheduler().runTaskAsynchronously(this.plugin, () -> {
-			Connection connection = this.sqlConnection.getConnection();
-			try {
-				connection.setAutoCommit(false);
-				PreparedStatement statement = connection.prepareStatement(INSERT_FORMAT);
-				for (PositionEntry entry : entries) {
-					entry.addInsertionToBatch(statement);
-				}
-				statement.executeBatch();
-				connection.commit();
-				statement.close();
-			} catch (SQLException e) {
-				e.printStackTrace();
-			}
-		});
-	}
+
+    public class PositionEntry {
+
+        private final int x, y, z;
+        private final String world, biome, username;
+        private final UUID uuid;
+        private final Timestamp time;
+
+        public PositionEntry(Player player) {
+            Location loc = player.getLocation();
+            this.x = loc.getBlockX();
+            this.y = loc.getBlockY();
+            this.z = loc.getBlockZ();
+            this.world = loc.getWorld().getName();
+            this.biome = loc.getBlock().getBiome().name();
+            this.username = player.getName();
+            this.uuid = player.getUniqueId();
+            this.time = new Timestamp(System.currentTimeMillis());
+        }
+
+        public void addInsertionToBatch(PreparedStatement statement) throws SQLException {
+            statement.setInt(1, x);
+            statement.setInt(2, y);
+            statement.setInt(3, z);
+            statement.setString(4, world);
+            statement.setString(5, biome);
+            statement.setString(6, username);
+            statement.setString(7, uuid.toString());
+            statement.setLong(8, time.getTime() / 1000);
+            statement.addBatch();
+        }
+
+    }
+
+    private static final String INSERT_FORMAT =
+            "INSERT INTO `whimc_player_positions` " +
+                    "(x, y, z, world, biome, username, uuid, time) " +
+                    "VALUES(?, ?, ?, ?, ?, ?, ?, ?)";
+
+    private Tracker plugin;
+    private MySQLConnection sqlConnection;
+
+    public Queryer(Tracker plugin, Consumer<Boolean> callback) {
+        this.plugin = plugin;
+        this.sqlConnection = new MySQLConnection(plugin);
+
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            final boolean success = sqlConnection.initialize();
+            Bukkit.getScheduler().runTask(plugin, () -> {
+                callback.accept(success);
+            });
+        });
+    }
+
+    public void storePositionData() {
+        final List<PositionEntry> entries = Bukkit.getOnlinePlayers().stream()
+                .map(PositionEntry::new)
+                .collect(Collectors.toList());
+
+        Bukkit.getScheduler().runTaskAsynchronously(this.plugin, () -> {
+            try (Connection connection = this.sqlConnection.getConnection()) {
+                connection.setAutoCommit(false);
+                try (PreparedStatement statement = connection.prepareStatement(INSERT_FORMAT)) {
+                    for (PositionEntry entry : entries) {
+                        entry.addInsertionToBatch(statement);
+                    }
+                    statement.executeBatch();
+                    connection.commit();
+                }
+            } catch (SQLException e) {
+                e.printStackTrace();
+            }
+        });
+    }
 }


### PR DESCRIPTION
Instead of constantly keeping the connection open and potentially timing out, a new connection will be created when we update the database. Better to eventually update to a connection pool.
Resolves #1 