### PR TITLE
Fixing SQL driver out of date error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>edu.whimc</groupId>
 	<artifactId>WHIMC-PositionTracker</artifactId>
-	<version>2.1.0</version>
+	<version>2.1.1</version>
 	<name>WHIMC Position Tracker</name>
 	<description>Track player positions to a database</description>
 

--- a/src/main/java/edu/whimc/positiontracker/sql/MySQLConnection.java
+++ b/src/main/java/edu/whimc/positiontracker/sql/MySQLConnection.java
@@ -11,8 +11,6 @@ import edu.whimc.positiontracker.Tracker;
  * Handles the connection to the SQL database.
  */
 public class MySQLConnection {
-	/** The SQL Driver class package. */
-	public static final String DRIVER_CLASS = "com.mysql.cj.jdbc.Driver";
 	/** The template for the URL. */
 	public static final String URL_TEMPLATE = "jdbc:mysql://%s:%s/%s";
 	/** The SQL command to create a table. */
@@ -88,9 +86,8 @@ public class MySQLConnection {
 			}
 
 			// try connecting if a connection doesn't currently exist
-			Class.forName(DRIVER_CLASS);
 			this.connection = DriverManager.getConnection(this.url, this.username, this.password);
-		} catch (SQLException | ClassNotFoundException e) {
+		} catch (SQLException ignored) {
 			return null;
 		}
 		

--- a/src/main/java/edu/whimc/positiontracker/sql/MySQLConnection.java
+++ b/src/main/java/edu/whimc/positiontracker/sql/MySQLConnection.java
@@ -12,7 +12,7 @@ import edu.whimc.positiontracker.Tracker;
  */
 public class MySQLConnection {
 	/** The SQL Driver class package. */
-	public static final String DRIVER_CLASS = "com.mysql.jdbc.Driver";
+	public static final String DRIVER_CLASS = "com.mysql.cj.jdbc.Driver";
 	/** The template for the URL. */
 	public static final String URL_TEMPLATE = "jdbc:mysql://%s:%s/%s";
 	/** The SQL command to create a table. */


### PR DESCRIPTION
Attempted to fix this:
```
15.10 14:02:20 [Server] ERROR ] com.mysql.jdbc.Driver Loading class `com.mysql.jdbc.Driver'. This is deprecated. The new driver class is `com.mysql.cj.jdbc.Driver'. The driver is automatically registered via the SPI and manual loading of the driver class is generally unnecessary.
```
But I am not very smart so I don't know if I did it right. 